### PR TITLE
Use gtm.js event instead of sdk.js

### DIFF
--- a/views/js/sdk.js
+++ b/views/js/sdk.js
@@ -33,13 +33,13 @@ TrackSmart.prototype.build = function()
         if (u !== null)
         {
             w[l].push({
-                'gtm.start': new Date().getTime(), event: 'sdk.js', user_id: u
+                'gtm.start': new Date().getTime(), event: 'gtm.js', user_id: u
             });
         }
         else
         {
             w[l].push({
-                'gtm.start': new Date().getTime(), event: 'sdk.js'
+                'gtm.start': new Date().getTime(), event: 'gtm.js'
             });
         }
 


### PR DESCRIPTION
Using sdk.js prevent the "Container Loader" event in GTM and the "All pages" event to work, so I reverted it to the standard "gtm.js"